### PR TITLE
Potential fix for code scanning alert no. 1: Client-side cross-site scripting

### DIFF
--- a/webmention-web-components/src/webmention-send.js
+++ b/webmention-web-components/src/webmention-send.js
@@ -91,12 +91,17 @@ export class WebmentionSend extends HTMLElement {
         this.innerHTML = `
         <form method="POST" action="${this._endpoint}">
             ${this._descriptiveText}
-            <input type="hidden" name="target" value="${window.location.href}">
+            <input type="hidden" name="target" value="">
             <label for="source">URL:</label>
             <input type="url" name="source" id="source" required>
             <button type="submit">Send Webmention</button>
         </form>
         `;
+
+        const targetInput = this.querySelector('input[name="target"]');
+        if (targetInput) {
+            targetInput.value = window.location.href;
+        }
 
         this.querySelector('form').addEventListener('submit', async (event) => {
             event.preventDefault();


### PR DESCRIPTION
Potential fix for [https://github.com/Maritims/webmention/security/code-scanning/1](https://github.com/Maritims/webmention/security/code-scanning/1)

In general, to fix this kind of problem you must not insert untrusted data into `innerHTML` without proper contextual escaping. For attribute values, the safest approach is to set them via DOM APIs (e.g., `element.setAttribute` or `element.value = ...`), letting the browser handle encoding, instead of concatenating strings into HTML.

For this specific code, the minimal, behavior-preserving fix is:

1. Stop interpolating `window.location.href` into the HTML template string.
2. After the form is inserted into the DOM, set the `target` input’s value using the DOM API (`input.value = window.location.href`). This avoids using `innerHTML` as a sink for the untrusted URL while keeping the same form behavior.

Concretely, in `webmention-web-components/src/webmention-send.js`:

- In `render()`, change the template so the hidden input is created with an empty value attribute (or without `value` entirely).
- Immediately after `this.innerHTML = ...;`, select that hidden input and assign `window.location.href` to its `.value` property.

No new imports or helper methods are required; we only rely on standard DOM APIs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
